### PR TITLE
Add dependency-check config xml to suppress false alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # codequality-rules
 Configuration files for various code quality analysis tools
 
+## dependency_check
+To suppress false-alert vulnerability reports, read this article and update dependency-check-suppression.xml
+
+https://jeremylong.github.io/DependencyCheck/general/suppression.html
+
 # Licensing
 For any particular file the LICENSE file in the same folder, otherwise the nearest parent LICENCE file applies.

--- a/dependency_check/dependency-check-suppressing.xml
+++ b/dependency_check/dependency-check-suppressing.xml
@@ -1,17 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress>
+  <!-- example -->
+  <!-- <suppress>
     <notes><![CDATA[
       file name: some.jar
       ]]></notes>
     <sha1>66734244CE86857018B023A8C56AE0635C56B6A1</sha1>
     <cpe>cpe:/a:apache:struts:2.0.0</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: spring-security-oauth2-2.0.15.RELEASE.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.security\.oauth/spring\-security\-oauth2@.*$</packageUrl>
-    <cpe>cpe:/a:security-framework_project:security-framework</cpe>
-  </suppress>
+  </suppress> -->
 </suppressions>

--- a/dependency_check/dependency-check-suppressing.xml
+++ b/dependency_check/dependency-check-suppressing.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress>
+    <notes><![CDATA[
+      file name: some.jar
+      ]]></notes>
+    <sha1>66734244CE86857018B023A8C56AE0635C56B6A1</sha1>
+    <cpe>cpe:/a:apache:struts:2.0.0</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-security-oauth2-2.0.15.RELEASE.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework\.security\.oauth/spring\-security\-oauth2@.*$</packageUrl>
+    <cpe>cpe:/a:security-framework_project:security-framework</cpe>
+  </suppress>
+</suppressions>


### PR DESCRIPTION
## why the change is needed
we need to have one xml file to suppress some false alerts.
related to https://github.com/Pay-Baymax/paypay-gradle-plugin/tree/issue/add-suppressing-xml

## what is the change
just added one file


