### PR TITLE
Exclude PMD rule for OnlyOneReturn

### DIFF
--- a/pmd/pmd-rules.xml
+++ b/pmd/pmd-rules.xml
@@ -20,6 +20,7 @@
         <exclude name="MethodArgumentCouldBeFinal"/>
         <exclude name="CommentDefaultAccessModifier"/>
         <exclude name="DefaultPackage"/>
+        <exclude name="OnlyOneReturn"/>
     </rule>
     <rule ref="category/java/design.xml">
         <exclude name="LawOfDemeter"/>


### PR DESCRIPTION
I would like to exclude the PMD rule for OnlyOneReturn. It is perfectly possible for a method to have more than one return statements.
https://pmd.github.io/pmd-6.5.0/pmd_rules_java_codestyle.html#onlyonereturn

Instead this rule should be replaced by sonar's rule for method should not have too many return statements. 
https://rules.sonarsource.com/java/RSPEC-1142